### PR TITLE
chore: enable commitlint

### DIFF
--- a/.commitlint/hooks/commit-msg
+++ b/.commitlint/hooks/commit-msg
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if ! type commitlint >/dev/null 2>/dev/null; then
+	echo ""
+    echo "commitlint could not be found"
+    echo "try again after installing commitlint or add commitlint to PATH"
+	echo ""
+    exit 2;
+fi
+
+commitlint lint --message $1
+


### PR DESCRIPTION
This pull request adds a new commit message hook to ensure commit messages adhere to the project's linting standards.

Commit message linting:

* [`.commitlint/hooks/commit-msg`](diffhunk://#diff-944456bf3000c6c8b70413a79571d110c0e297bff5bc396a8b43625ae60bbddaR1-R12): Added a shell script to check if `commitlint` is installed and use it to lint commit messages. If `commitlint` is not found, an error message is displayed, and the script exits with status code 2.

The project uses `commitlint` found here: https://github.com/conventionalcommit/commitlint