### PR TITLE
fix: Use hardcoded git-cliff repo information

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% for commit in commits %}
         - {{ commit.message | upper_first }}{% for f in commit.footers -%}
         {% if f.token in ["Resolves", "Fixes"] -%}
-        {{ " (" ~ f.token }} [{{ f.value }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/issues/{{ f.value | trim_start_matches(pat="#") }}))
+        {{ " (" ~ f.token }} [{{ f.value }}](https://github.com/rhysparry/Dirt.Args/issues/{{ f.value | trim_start_matches(pat="#") }}))
         {%- endif -%}
         {% endfor %}\
     {% endfor %}
@@ -35,11 +35,11 @@ footer = """
     {% if release.version -%}
         {% if release.previous.version -%}
             [{{ release.version | trim_start_matches(pat="v") }}]: \
-                https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                https://github.com/rhysparry/Dirt.Args\
                     /compare/{{ release.previous.version }}..{{ release.version }}
         {% endif -%}
     {% else -%}
-        [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+        [unreleased]: https://github.com/rhysparry/Dirt.Args\
             /compare/{{ release.previous.version }}..HEAD
     {% endif -%}
 {% endfor %}


### PR DESCRIPTION
This pull request includes updates to the `cliff.toml` file to correct the repository URL for issue and release links. The changes ensure that the links point to the correct repository, `rhysparry/Dirt.Args`.

Updates to repository URLs:

* [`cliff.toml`](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584L26-R26): Updated issue links to point to `rhysparry/Dirt.Args` repository instead of using placeholders for the GitHub owner and repo.
* [`cliff.toml`](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584L38-R42): Updated release comparison links to point to `rhysparry/Dirt.Args` repository instead of using placeholders for the GitHub owner and repo.