### PR TITLE
fix(build): Set version without requiring `sed`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 export NuGetApiKey := env("NUGET_API_KEY", "")
-export Version := `git-cliff --bumped-version | sed 's/^v//'`
+export Version := trim_start_match(`git-cliff --bumped-version`, "v")
 
 restore:
     ./build.cmd -target Restore


### PR DESCRIPTION
This pull request includes a small but important change to the `justfile` to enhance the version extraction process.

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L2-R2): Modified the `Version` export to use `trim_start_match` instead of `sed` for removing the 'v' prefix from the version string.