### PR TITLE
build: Use `pwsh` as `justfile` shell on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
+
 export NuGetApiKey := env("NUGET_API_KEY", "")
 export Version := trim_start_match(`git-cliff --bumped-version`, "v")
 


### PR DESCRIPTION
This pull request includes a small change to the `justfile`. The change sets the `windows-shell` to use `pwsh.exe` with specific parameters.

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R1-R2): Added a line to set the `windows-shell` to `["pwsh.exe", "-NoProfile", "-c"]`.