### PR TITLE
chore(build): use `just` to manage build

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -17,6 +17,8 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
 
         - name: Setup .NET Core 6
           uses: actions/setup-dotnet@v4
@@ -26,5 +28,9 @@ jobs:
           uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '8.0.x'
+        - name: "Install tools"
+          uses: taiki-e/install-action@v2
+          with:
+            tool: just@1.36.0,git-cliff@2.6.1
         - name: Test
-          run: ./build.sh -target Test
+          run: just test

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -12,6 +12,8 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
 
         - name: Setup .NET Core 6
           uses: actions/setup-dotnet@v4
@@ -21,13 +23,17 @@ jobs:
           uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '8.0.x'
+        - name: "Install tools"
+          uses: taiki-e/install-action@v2
+          with:
+            tool: just@1.36.0,git-cliff@2.6.1
 
         - name: Test
-          run: ./build.sh -target Test
-          if: ${{ ! startsWith(github.ref, 'refs/heads/main') }}
+          run: just test
+          if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
 
         - name: Pack
-          run: ./build.sh -target Pack
+          run: just pack
           if: startsWith(github.ref, 'refs/tags/v')
 
         - name: Create a release with the NuGet Package
@@ -46,6 +52,6 @@ jobs:
           if: startsWith(github.ref, 'refs/tags/v')
 
         - name: Push NuGet package
-          run: ./build.sh -skip Pack -target Publish
+          run: just nuget-push-no-pack
           if: startsWith(github.ref, 'refs/tags/v')
 

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -9,6 +9,10 @@
         "Release"
       ]
     },
+    "GithubRef": {
+      "type": "string",
+      "description": "GitHub Ref"
+    },
     "NuGetApiKey": {
       "type": "string",
       "description": "NuGet API key",

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.1.1" />
+    <PackageReference Include="NUlid" Version="1.7.2" />
   </ItemGroup>
 
 </Project>

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ build:
 test:
     ./build.cmd -target Test
 
-pack: build
+pack:
     ./build.cmd -target Pack
 
 clean:
@@ -20,6 +20,9 @@ clean:
 
 nuget-push:
     ./build.cmd -target Publish
+    
+nuget-push-no-pack:
+    ./build.cmd -target Publish -skip Pack
 
 changelog:
     git-cliff --output CHANGELOG.md

--- a/justfile
+++ b/justfile
@@ -3,26 +3,32 @@ set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
 export NuGetApiKey := env("NUGET_API_KEY", "")
 export Version := trim_start_match(`git-cliff --bumped-version`, "v")
 
+build-cmd := if os_family() == "windows" {
+    "build.cmd"
+} else {
+    "./build.sh"
+}
+
 restore:
-    ./build.cmd -target Restore
+    {{build-cmd}} -target Restore
 
 build: 
-    ./build.cmd -target Compile
+    {{build-cmd}} -target Compile
 
 test:
-    ./build.cmd -target Test
+    {{build-cmd}} -target Test
 
 pack:
-    ./build.cmd -target Pack
+    {{build-cmd}} -target Pack
 
 clean:
-    ./build.cmd -target Clean
+    {{build-cmd}} -target Clean
 
 nuget-push:
-    ./build.cmd -target Publish
+    {{build-cmd}} -target Publish
     
 nuget-push-no-pack:
-    ./build.cmd -target Publish -skip Pack
+    {{build-cmd}} -target Publish -skip Pack
 
 changelog:
     git-cliff --output CHANGELOG.md


### PR DESCRIPTION
This pull request includes several updates to the CI/CD workflows, build scripts, and project configuration files to improve the build process and tool management. The most important changes include adding new tool installations, updating build commands, and introducing new parameters and dependencies.

### CI/CD Workflow Improvements:
* [`.github/workflows/dotnet-ci-build.yml`](diffhunk://#diff-64f5936e0eb6a6a2f3ef0074806a112b100df2a431e4abee6283eb2b543bdfbcR31-R36): Added a step to install `just` and `git-cliff` tools, and modified the test command to use `just test`.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R26-R36): Added a step to install `just` and `git-cliff` tools, updated the test, pack, and push commands to use `just`, and changed the condition for the test step. [[1]](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R26-R36) [[2]](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L49-R55)

### Build Script Enhancements:
* [`build/Build.cs`](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L25-R51): Introduced new parameters for `GitHub Ref`, added `GitRepository` and `BuildId` properties, and updated the build and pack commands to use a dynamically generated version. [[1]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L25-R51) [[2]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L56-R82) [[3]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32L82-R108) [[4]](diffhunk://#diff-1d13dffe616bc5b18037d92d2dff9070e9a8522a8852ff8cf425a1aaad4dff32R120)
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R6-R31): Introduced a `build-cmd` variable to handle cross-platform build commands and updated all targets to use this variable. Added a new target `nuget-push-no-pack`.

### Configuration Updates:
* [`.nuke/build.schema.json`](diffhunk://#diff-f42806ceeba68d787c1eb3f3e90f9c02fbce599f09ba7d9520a2dc5b4fb58823R12-R15): Added a new `GithubRef` parameter to the schema.
* [`build/_build.csproj`](diffhunk://#diff-7b133e20a4f96a79bedd410be3af66b7cf9e75453baaa14cb68d3dd09da21dc6R17): Added a package reference for `NUlid` to support the new `BuildId` property.

These changes collectively enhance the build process, making it more flexible and maintainable.