### PR TITLE
chore(build): enable deterministic builds

### DIFF
--- a/Dirt.Args/Dirt.Args.csproj
+++ b/Dirt.Args/Dirt.Args.csproj
@@ -22,5 +22,15 @@
         <None Include="..\README.md" Pack="true" PackagePath="\" />
         <None Include="..\CHANGELOG.md" Pack="true" PackagePath="\" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes changes to the `Dirt.Args.csproj` file to improve the build process and package management.

Build process improvements:

* Added a `PropertyGroup` to set `ContinuousIntegrationBuild` to `true` when the `GITHUB_ACTIONS` environment variable is set to `true` (`Dirt.Args/Dirt.Args.csproj`).

Package management improvements:

* Added a `PackageReference` for `Microsoft.SourceLink.GitHub` version `8.0.0` with `PrivateAssets` set to `all` (`Dirt.Args/Dirt.Args.csproj`).

This enables [SourceLink](https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/) in the package and should ensure deterministic builds in CI.