### PR TITLE
chore: set .gitattributes for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.nuke/build.schema.json text=auto


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file. The change ensures that the `build.schema.json` file is treated as text with automatic line-endings by Git. This allows Windows-users that don't enable autocrlf (because line endings are already managed) to still have the desired behavior on files that are generated with the crlf line endings.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1): Added an entry to treat `.nuke/build.schema.json` as text.