### PR TITLE
build(fix): build.cmd invocation in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ export NuGetApiKey := env("NUGET_API_KEY", "")
 export Version := trim_start_match(`git-cliff --bumped-version`, "v")
 
 build-cmd := if os_family() == "windows" {
-    "build.cmd"
+    "./build.cmd"
 } else {
     "./build.sh"
 }


### PR DESCRIPTION
This pull request includes a small but important change to the `justfile`. The change modifies the command used to build the project on Windows to ensure it is executed correctly.

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L7-R7): Changed the Windows build command from `"build.cmd"` to `"./build.cmd"` to ensure the script is executed correctly.