### PR TITLE
chore(build): apply `EmbedUntrackedSources`

### DIFF
--- a/Dirt.Args/Dirt.Args.csproj
+++ b/Dirt.Args/Dirt.Args.csproj
@@ -31,6 +31,7 @@
 
     <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes a small change to the `Dirt.Args/Dirt.Args.csproj` file. The change enables the embedding of untracked sources during continuous integration builds.

* [`Dirt.Args/Dirt.Args.csproj`](diffhunk://#diff-fa5bee25be9581821033e2da5a646795ec288da79fd287cfdd1dd048c8832570R34): Added the `<EmbedUntrackedSources>` property to the `<PropertyGroup>` for GitHub Actions builds.