### PR TITLE
chore(build): Update build schema

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,32 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-    "Configuration": {
-      "type": "string",
-      "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-      "enum": [
-        "Debug",
-        "Release"
-      ]
-    },
-    "GithubRef": {
-      "type": "string",
-      "description": "GitHub Ref"
-    },
-    "NuGetApiKey": {
-      "type": "string",
-      "description": "NuGet API key",
-      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-    },
-    "Solution": {
-      "type": "string",
-      "description": "Path to a solution file that is automatically loaded"
-    },
-    "Version": {
-      "type": "string",
-      "description": "Version to use"
-    }
-  },
   "definitions": {
     "Host": {
       "type": "string",
@@ -127,5 +100,38 @@
       }
     }
   },
-  "$ref": "#/definitions/NukeBuild"
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "GithubRef": {
+          "type": "string",
+          "description": "GitHub Ref"
+        },
+        "NuGetApiKey": {
+          "type": "string",
+          "description": "NuGet API key",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Version": {
+          "type": "string",
+          "description": "Version to use"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
+    }
+  ]
 }


### PR DESCRIPTION
Recent Nuke.Build update impacts the build schema.

This pull request includes changes to the `.nuke/build.schema.json` file to restructure the JSON schema and improve its organization. The most important changes include moving properties into an `allOf` array and referencing the `NukeBuild` definition.

Schema restructuring:

* Moved the `Configuration`, `GithubRef`, `NuGetApiKey`, `Solution`, and `Version` properties into an `allOf` array. [[1]](diffhunk://#diff-f42806ceeba68d787c1eb3f3e90f9c02fbce599f09ba7d9520a2dc5b4fb58823L3-L29) [[2]](diffhunk://#diff-f42806ceeba68d787c1eb3f3e90f9c02fbce599f09ba7d9520a2dc5b4fb58823R103-R137)
* Added a reference to the `NukeBuild` definition within the `allOf` array.