### PR TITLE
chore(build): Remove net6.0 references

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -19,11 +19,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
-
-        - name: Setup .NET Core 6
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '6.0.x'
         - name: Setup .NET Core 8
           uses: actions/setup-dotnet@v4
           with:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -14,11 +14,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
-
-        - name: Setup .NET Core 6
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '6.0.x'
         - name: Setup .NET Core 8
           uses: actions/setup-dotnet@v4
           with:

--- a/Dirt.Args.Tests/Dirt.Args.Tests.csproj
+++ b/Dirt.Args.Tests/Dirt.Args.Tests.csproj
@@ -7,7 +7,7 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
         <LangVersion>12</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
This pull request updates the .NET Core version used in the CI workflows and modifies the target frameworks for the test project. The most important changes include:

### CI Workflow Updates:
* [`.github/workflows/dotnet-ci-build.yml`](diffhunk://#diff-64f5936e0eb6a6a2f3ef0074806a112b100df2a431e4abee6283eb2b543bdfbcL22-L26): Removed setup for .NET Core 6.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L17-L21): Removed setup for .NET Core 6.

### Project Configuration:
* [`Dirt.Args.Tests/Dirt.Args.Tests.csproj`](diffhunk://#diff-8a5e340d69dbac20eddb186ec4a295a2000d0600cca154192c7da295acf07479L10-R10): Changed the target frameworks from `net8.0;net6.0` to `net8.0` for the test project.

Resolves: #38