### PR TITLE
chore(build): Add testing on net48 runtime

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -9,25 +9,25 @@ on:
       - main
 
 jobs:
-    build:
-        env:
-          BUILD_CONFIGURATION: Debug
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ubuntu-latest, windows-latest]
-        steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-        - name: Setup .NET Core 8
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '8.0.x'
-        - name: "Install tools"
-          uses: taiki-e/install-action@v2
-          with:
-            tool: just@1.36.0,git-cliff@2.6.1
-        - name: Test
-          run: just test
+  build:
+    env:
+      BUILD_CONFIGURATION: Debug
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET Core 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: "Install tools"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.36.0,git-cliff@2.6.1
+      - name: Test
+        run: just test

--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -12,8 +12,10 @@ jobs:
     build:
         env:
           BUILD_CONFIGURATION: Debug
-        runs-on: ubuntu-latest
-
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-latest, windows-latest]
         steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -6,9 +6,26 @@ on:
       - 'v*.*.*'
 
 jobs:
+    test:
+      runs-on: windows-latest
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET Core 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: "Install tools"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.36.0,git-cliff@2.6.1
+      - name: Test
+        run: just test
     build:
         runs-on: ubuntu-latest
-
+        needs: test
         steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -6,9 +6,9 @@ on:
       - 'v*.*.*'
 
 jobs:
-    test:
-      runs-on: windows-latest
-      steps:
+  test:
+    runs-on: windows-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -23,47 +23,41 @@ jobs:
           tool: just@1.36.0,git-cliff@2.6.1
       - name: Test
         run: just test
-    build:
-        runs-on: ubuntu-latest
-        needs: test
-        steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-        - name: Setup .NET Core 8
-          uses: actions/setup-dotnet@v4
-          with:
-            dotnet-version: '8.0.x'
-        - name: "Install tools"
-          uses: taiki-e/install-action@v2
-          with:
-            tool: just@1.36.0,git-cliff@2.6.1
-
-        - name: Test
-          run: just test
-          if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
-
-        - name: Pack
-          run: just pack
-          if: startsWith(github.ref, 'refs/tags/v')
-
-        - name: Create a release with the NuGet Package
-          uses: softprops/action-gh-release@v2
-          with:
-            files: '**/*.nupkg'
-          if: startsWith(github.ref, 'refs/tags/v')
-
-        - name: Load NuGet API Key
-          uses: 1password/load-secrets-action@v2
-          with:
-            export-env: true
-          env:
-            OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-            NUGET_API_KEY: "op://GitHub Actions/NuGet API Dirt/credential"
-          if: startsWith(github.ref, 'refs/tags/v')
-
-        - name: Push NuGet package
-          run: just nuget-push-no-pack
-          if: startsWith(github.ref, 'refs/tags/v')
-
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup .NET Core 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: "Install tools"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just@1.36.0,git-cliff@2.6.1
+      - name: Test
+        run: just test
+        if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+      - name: Pack
+        run: just pack
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Create a release with the NuGet Package
+        uses: softprops/action-gh-release@v2
+        with:
+          files: '**/*.nupkg'
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Load NuGet API Key
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          NUGET_API_KEY: "op://GitHub Actions/NuGet API Dirt/credential"
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Push NuGet package
+        run: just nuget-push-no-pack
+        if: startsWith(github.ref, 'refs/tags/v')

--- a/Dirt.Args.Tests/Dirt.Args.Tests.csproj
+++ b/Dirt.Args.Tests/Dirt.Args.Tests.csproj
@@ -4,14 +4,17 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Dirt.Tests</RootNamespace>
-
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
-
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
TL;DR: CI run on Windows testing net48 runtime with netstandard2.0 targetted libraries.

This pull request includes several changes to the CI/CD workflows and the test project configuration to improve compatibility and streamline the build and release processes. The most important changes are grouped by theme below:

### CI/CD Workflow Improvements:

* [`.github/workflows/dotnet-ci-build.yml`](diffhunk://#diff-64f5936e0eb6a6a2f3ef0074806a112b100df2a431e4abee6283eb2b543bdfbcL15-R18): Updated the `runs-on` parameter to use a matrix strategy, allowing the build to run on both `ubuntu-latest` and `windows-latest` environments.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R9-R28): Added a new `test` job that runs on `windows-latest` and includes steps for checkout, setting up .NET Core 8, installing tools, and running tests. The `build` job now depends on the `test` job.

### Test Project Configuration:

* [`Dirt.Args.Tests/Dirt.Args.Tests.csproj`](diffhunk://#diff-8a5e340d69dbac20eddb186ec4a295a2000d0600cca154192c7da295acf07479L7-R17): Modified the project file to conditionally target different frameworks based on the operating system. For Windows, it targets both `net8.0` and `net48`, while for other operating systems, it targets `net8.0` only.

These changes enhance the flexibility and robustness of the CI/CD process by ensuring compatibility with multiple operating systems and improving the test project's configuration.

chore(build): Add testing on net48 runtime

Resolves: #39

chore: reformat github workflow files