### PR TITLE
chore: link to pull requests in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -66,6 +66,10 @@ commit_parsers = [
   { message = "^.*: [Ff]ix", group = "Fixed" },
   { message = "^.*", group = "Changed" },
 ]
+# Pre-process commits
+commit_preprocessors = [
+  { pattern = "\\(#(\\d+)\\)", replace = "([#$1](https://github.com/rhysparry/Dirt.Args/pull/$1))" }
+]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers


### PR DESCRIPTION
This pull request includes a change to the `cliff.toml` file to pre-process commit messages by adding a new commit preprocessor configuration.

Improvements to commit message processing:

* [`cliff.toml`](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584R69-R72): Added a `commit_preprocessors` section to replace patterns in commit messages with GitHub pull request links.