### PR TITLE
chore: enable generation of release notes

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ build-cmd := if os_family() == "windows" {
 } else {
     "./build.sh"
 }
+mkdir-p := if os_family() == "windows" { "New-Item -Type Directory -Force" } else { "mkdir -p" }
 
 restore:
     {{build-cmd}} -target Restore
@@ -29,6 +30,13 @@ nuget-push:
     
 nuget-push-no-pack:
     {{build-cmd}} -target Publish -skip Pack
+
+[private]
+artifacts-dir:
+    {{ mkdir-p }} artifacts
+
+release-notes: artifacts-dir
+    git-cliff --latest --strip header --output artifacts/RELEASE-NOTES.md
 
 changelog:
     git-cliff --output CHANGELOG.md

--- a/justfile
+++ b/justfile
@@ -2,34 +2,29 @@ set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
 
 export NuGetApiKey := env("NUGET_API_KEY", "")
 export Version := trim_start_match(`git-cliff --bumped-version`, "v")
-
-build-cmd := if os_family() == "windows" {
-    "./build.cmd"
-} else {
-    "./build.sh"
-}
+build-cmd := if os_family() == "windows" { "./build.cmd" } else { "./build.sh" }
 mkdir-p := if os_family() == "windows" { "New-Item -Type Directory -Force" } else { "mkdir -p" }
 
 restore:
-    {{build-cmd}} -target Restore
+    {{ build-cmd }} -target Restore
 
-build: 
-    {{build-cmd}} -target Compile
+build:
+    {{ build-cmd }} -target Compile
 
 test:
-    {{build-cmd}} -target Test
+    {{ build-cmd }} -target Test
 
 pack:
-    {{build-cmd}} -target Pack
+    {{ build-cmd }} -target Pack
 
 clean:
-    {{build-cmd}} -target Clean
+    {{ build-cmd }} -target Clean
 
 nuget-push:
-    {{build-cmd}} -target Publish
-    
+    {{ build-cmd }} -target Publish
+
 nuget-push-no-pack:
-    {{build-cmd}} -target Publish -skip Pack
+    {{ build-cmd }} -target Publish -skip Pack
 
 [private]
 artifacts-dir:


### PR DESCRIPTION
This pull request includes changes to the `justfile` to streamline commands and introduce new tasks for managing artifacts and release notes. The most important changes include simplifying command definitions for different operating systems and adding new tasks for creating directories and generating release notes.

Streamlining command definitions:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L5-R6): Simplified the `build-cmd` definition by consolidating the conditional statement into a single line.
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L5-R6): Added a new `mkdir-p` command definition to handle directory creation for both Windows and Unix-like systems.

New tasks for artifacts and release notes:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R29-R35): Introduced a new `artifacts-dir` task to create the `artifacts` directory.
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R29-R35): Added a `release-notes` task that generates release notes using `git-cliff` and outputs them to `artifacts/RELEASE-NOTES.md`.

chore: enable generation of release notes

chore: format justfile