### PR TITLE
chore: configure dependabot to manage sdk updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,17 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    assignees:
+      - "rhysparry"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
This pull request includes a significant update to the `.github/dependabot.yml` file to add a new package ecosystem configuration for `dotnet-sdk`. The most important change involves adding a new schedule for dependency updates and assigning a specific team member to handle these updates.

Changes to dependency update configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R33-R46): Added a new `dotnet-sdk` package ecosystem with a weekly update schedule on Wednesdays, ignoring major version updates, and assigning updates to `rhysparry`.