### PR TITLE
chore: Generate release notes for GitHub

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -45,10 +45,16 @@ jobs:
       - name: Pack
         run: just pack
         if: startsWith(github.ref, 'refs/tags/v')
+      - name: Create Release Notes
+        run: just release-notes
+        if: startsWith(github.ref, 'refs/tags/v')
       - name: Create a release with the NuGet Package
         uses: softprops/action-gh-release@v2
         with:
-          files: '**/*.nupkg'
+          body_path: artifacts/RELEASE-NOTES.md
+          files: |
+            artifacts/*.nupkg
+            artifacts/*.snupkg
         if: startsWith(github.ref, 'refs/tags/v')
       - name: Load NuGet API Key
         uses: 1password/load-secrets-action@v2


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/nuget-publish.yml` file to enhance the release process by adding release notes and including additional artifacts in the release.

Enhancements to the release process:

* Added a step to create release notes using the `just release-notes` command.
* Modified the release creation step to include the release notes file and additional artifact files (`.nupkg` and `.snupkg`).