### PR TITLE
chore: Add recipes to assist in releasing

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -57,6 +57,7 @@ filter_unconventional = true
 split_commits = false
 # regex for parsing and grouping commits
 commit_parsers = [
+  { message = "^chore.release.: release", skip = true },
   { message = "^.*: [Aa]dd", group = "Added" },
   { message = "^.*: [Ss]upport", group = "Added" },
   { message = "^.*: [Rr]emove", group = "Removed" },


### PR DESCRIPTION
This pull request introduces several changes to automate the release process and ensure consistency across different environments. The most important changes include adding steps to generate release notes, updating the `justfile` to assert branch and pending changes, and modifying the `cliff.toml` configuration to skip certain commit messages.

Enhancements to release automation:

* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R48-R57): Added a step to create release notes and updated the release creation step to include additional artifacts.

Configuration improvements:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R38-R65): Added commands to assert the current branch and check for pending changes before proceeding with the release process.
* [`cliff.toml`](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584R60): Updated the commit parser configuration to skip commits with messages starting with "chore.release: release".