### PR TITLE
chore(pre-commit): Remove UTF-8 byte order marker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,5 +6,6 @@ repos:
     - id: check-json
     - id: check-toml
     - id: check-yaml
+    - id: fix-byte-order-marker
     - id: end-of-file-fixer
     - id: trailing-whitespace

--- a/Dirt.Args.sln
+++ b/Dirt.Args.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/Dirt.Args/Args.cs
+++ b/Dirt.Args/Args.cs
@@ -1,4 +1,4 @@
-﻿namespace Dirt;
+namespace Dirt;
 
 /// <summary>
 /// Represents a collection of command-line arguments.

--- a/Dirt.Args/Dirt.Args.csproj
+++ b/Dirt.Args/Dirt.Args.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>

--- a/build/_build.csproj.DotSettings
+++ b/build/_build.csproj.DotSettings
@@ -1,4 +1,4 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeapView_002EDelegateAllocation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VariableHidesOuterVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>


### PR DESCRIPTION
This pull request includes several changes to various configuration and project files to clean up and standardize the codebase. The most important changes include adding a new pre-commit hook, and fixing byte order marks across multiple files.

Improvements to configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R9): Added a new pre-commit hook `fix-byte-order-marker` to ensure files are free of byte order marks.

Fixes to byte order marks:

* [`Dirt.Args.sln`](diffhunk://#diff-b064ee7b0a57a276cad11e6dad04ff47b1d59e7d56614f71df01b02cda5606adL1-R1): Removed byte order mark from the beginning of the file.
* [`Dirt.Args/Args.cs`](diffhunk://#diff-87b0b47bbb31ff2713a66acfac6a2e0e95a413680e0cacc54c35ffdad0b2815aL1-R1): Removed byte order mark from the beginning of the file.
* [`Dirt.Args/Dirt.Args.csproj`](diffhunk://#diff-fa5bee25be9581821033e2da5a646795ec288da79fd287cfdd1dd048c8832570L1-R1): Removed byte order mark from the beginning of the file.
* [`build/_build.csproj.DotSettings`](diffhunk://#diff-a15bbf44d442c116752a4e604be77e71d55680d12a5164321e17440fb3f0bdaaL1-R1): Removed byte order mark from the beginning of the file.