### PR TITLE
chore(pre-commit): enable commitlint

### DIFF
--- a/.commitlint.yaml
+++ b/.commitlint.yaml
@@ -1,0 +1,32 @@
+version: v0.9.0
+formatter: default
+rules:
+- header-min-length
+- header-max-length
+- body-max-line-length
+- footer-max-line-length
+- type-enum
+severity:
+  default: error
+settings:
+  body-max-line-length:
+    argument: 72
+  footer-max-line-length:
+    argument: 72
+  header-min-length:
+    argument: 10
+  header-max-length:
+    argument: 50
+  type-enum:
+    argument:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - perf
+    - test
+    - build
+    - ci
+    - chore
+    - revert

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
     - id: trailing-whitespace
 - repo: local
   hooks:
+    - id: commitlint
+      name: Lint commit message
+      entry: commitlint lint --message
+      language: system
+      stages:
+        - commit-msg
     - id: csharpier
       name: Format C#
       entry: dotnet tool run dotnet-csharpier


### PR DESCRIPTION
This pull request introduces new commit message linting rules and integrates the `commitlint` tool into the pre-commit configuration. The most important changes include the addition of a `.commitlint.yaml` configuration file and the integration of `commitlint` into the pre-commit hooks.

Commit message linting:

* [`.commitlint.yaml`](diffhunk://#diff-1ec08e5a9c0e187b15d40e8e2cd875c50fe8ce8038de92bcfa227f4f8a84b384R1-R32): Added a configuration file specifying the version, formatter, rules for commit message length, and allowed types of commits.

Pre-commit configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R14-R19): Integrated `commitlint` into the pre-commit hooks to ensure commit messages are linted according to the rules specified in `.commitlint.yaml`.