### PR TITLE
chore(pre-commit): enable GitHub action linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
     - id: fix-byte-order-marker
     - id: end-of-file-fixer
     - id: trailing-whitespace
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.4
+  hooks:
+    - id: actionlint
 - repo: local
   hooks:
     - id: commitlint


### PR DESCRIPTION
This pull request includes a small change to the `.pre-commit-config.yaml` file. The change adds a new repository and hook for actionlint to the pre-commit configuration.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R12-R15): Added the `actionlint` repository and hook to the pre-commit configuration.