### PR TITLE
chore(pre-commit): Configure pre-commit defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0


### PR DESCRIPTION
This pull request includes a small change to the `.pre-commit-config.yaml` file. The change adds default install hook types and default stages to the configuration.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R5): Added `default_install_hook_types` and `default_stages` to the configuration.