### PR TITLE
chore(pre-commit): Enable pre-commit GitHub action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: "Restore dotnet tools"
+        run: dotnet tool restore
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for pre-commit checks. The workflow is triggered on pull requests and pushes to the `main` branch. It ensures that code quality checks are automatically run before commits are finalized.

Key changes:

* Added a new GitHub Actions workflow configuration file: `.github/workflows/pre-commit.yml`.
* The workflow is set to trigger on pull requests and pushes to the `main` branch.
* The workflow runs on the `ubuntu-latest` environment and includes steps to set up Python, .NET, and restore .NET tools.
* The workflow uses the `pre-commit` action to enforce pre-commit hooks.