### PR TITLE
chore(deps): update xunit to v3

### DIFF
--- a/Dirt.Args.Tests/Dirt.Args.Tests.csproj
+++ b/Dirt.Args.Tests/Dirt.Args.Tests.csproj
@@ -6,7 +6,7 @@
         <RootNamespace>Dirt.Tests</RootNamespace>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <OutputType>Library</OutputType>
+        <OutputType>Exe</OutputType>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -17,8 +17,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="xunit.v3" Version="1.0.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This pull request includes updates to the `Dirt.Args.Tests` project file to change the output type and update package references. The most important changes include modifying the output type from a library to an executable and updating the xUnit package references to their latest versions.

Project configuration changes:

* [`Dirt.Args.Tests/Dirt.Args.Tests.csproj`](diffhunk://#diff-8a5e340d69dbac20eddb186ec4a295a2000d0600cca154192c7da295acf07479L9-R9): Changed the `<OutputType>` from `Library` to `Exe` to ensure the project builds as an executable.

Package updates:

* [`Dirt.Args.Tests/Dirt.Args.Tests.csproj`](diffhunk://#diff-8a5e340d69dbac20eddb186ec4a295a2000d0600cca154192c7da295acf07479L20-R21): Updated the xUnit package references to `xunit.v3` version `1.0.0` and `xunit.runner.visualstudio` version `3.0.0` for compatibility with the latest testing framework.