### PR TITLE
chore: pin github actions to ubuntu-24.04

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-latest ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Test
         run: just test
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: test
     steps:
       - name: Checkout

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This pull request updates the operating system versions used in several GitHub Actions workflows to ensure compatibility with the latest versions of Ubuntu.

Updates to GitHub Actions workflows:

* [`.github/workflows/dotnet-ci-build.yml`](diffhunk://#diff-64f5936e0eb6a6a2f3ef0074806a112b100df2a431e4abee6283eb2b543bdfbcL18-R18): Changed the `runs-on` parameter to use `ubuntu-24.04` instead of `ubuntu-latest` in the `matrix` strategy.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L27-R27): Updated the `runs-on` parameter to use `ubuntu-24.04` instead of `ubuntu-latest` for the `build` job.
* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036L11-R11): Modified the `runs-on` parameter to use `ubuntu-24.04` instead of `ubuntu-latest` for the `pre-commit` job.