### PR TITLE
chore: pin github actions to windows-2022

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-24.04, windows-latest ]
+        os: [ ubuntu-24.04, windows-2022 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow configurations to ensure compatibility with the latest environments.

Changes to CI/CD workflow configurations:

* [`.github/workflows/dotnet-ci-build.yml`](diffhunk://#diff-64f5936e0eb6a6a2f3ef0074806a112b100df2a431e4abee6283eb2b543bdfbcL18-R18): Updated the `runs-on` parameter in the `matrix` strategy to use `windows-2022` instead of `windows-latest`.
* [`.github/workflows/nuget-publish.yml`](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4L10-R10): Changed the `runs-on` parameter for the `test` job to use `windows-2022` instead of `windows-latest`.