### PR TITLE
chore: bundle xunit.v3 in test dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       test-dependencies:
         patterns:
           - Microsoft.NET.Test.Sdk
-          - xunit
+          - xunit.v3
           - xunit.runner.visualstudio
           - coverlet.collector
   - package-ecosystem: "github-actions" # See documentation for possible values


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change updates the test dependency pattern from `xunit` to `xunit.v3`.