### PR TITLE
chore: add lint recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,3 +63,10 @@ release: (assert-branch "main") assert-no-pending-changes && push-release
 [private, confirm("Are you sure you want to push the release?")]
 push-release:
     git push origin main --tags
+
+[private]
+restore-tools:
+    dotnet tool restore
+
+lint: restore-tools
+    pre-commit run --all-files


### PR DESCRIPTION
This pull request introduces a new `restore-tools` task and updates the `lint` task to include tool restoration in the `justfile`. These changes ensure that all necessary tools are restored before running lint checks.

Changes to `justfile`:

* Added a new `restore-tools` task to restore .NET tools using `dotnet tool restore`.
* Updated the `lint` task to depend on the `restore-tools` task, ensuring tools are restored before linting.