### PR TITLE
chore(deps): upgrade to .net 10 SDK

### DIFF
--- a/.github/workflows/dotnet-ci-build.yml
+++ b/.github/workflows/dotnet-ci-build.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup .NET Core 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: "Install tools"
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -13,10 +13,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup .NET Core 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: "Install tools"
         uses: taiki-e/install-action@v2
         with:
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup .NET Core 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: "Install tools"
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v6
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: "Restore dotnet tools"
         run: dotnet tool restore
       - uses: pre-commit/action@v3.0.1

--- a/Dirt.Args.Tests/Dirt.Args.Tests.csproj
+++ b/Dirt.Args.Tests/Dirt.Args.Tests.csproj
@@ -9,10 +9,10 @@
     <LangVersion>12</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;net48</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/Dirt.Args/Dirt.Args.csproj
+++ b/Dirt.Args/Dirt.Args.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "8.0.416",
+		"version": "10.0.101",
 		"rollForward": "latestFeature"
 	}
 }


### PR DESCRIPTION
Updates the project to the .NET 10 SDK with the following key changes:

- `global.json` uses 10.0.101 SDK
- Main library now builds net10.0 variant
- Tests are now run on net10.0 runtime
- Updates GitHub workflows to ensure net10.0 is installed
- Migrates Nuke Build to use .NET 10 SDK

Resolves: #118