### PR TITLE
fix: create artifacts folder for release notes

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ assert-no-pending-changes:
 assert-no-pending-changes:
     [ -z "$(git status --porcelain)" ]
 
-release: (assert-branch "main") assert-no-pending-changes && push-release
+release: (assert-branch "main") assert-no-pending-changes artifacts-dir && push-release
     git pull
     git-cliff --bump --output CHANGELOG.md
     git-cliff --bump --unreleased --strip header --output artifacts/RELEASE-NOTES.md


### PR DESCRIPTION
When generating the release notes, we need to make sure that the artifacts directory exists as it is where we will store the notes.

We already have the `artifacts-dir` recipe to create the directory, so it should just be added as a dependency to the `release` recipe.

Resolves: #126